### PR TITLE
Ensuring responses in make_pi_v are positive

### DIFF
--- a/coconut/proofs.py
+++ b/coconut/proofs.py
@@ -69,7 +69,7 @@ def make_pi_v(params, aggr_vk, sigma, private_m, t):
 	c = to_challenge([g1, g2, alpha, Aw, Bw]+hs+beta)
 	# create responses 
 	rm = [(wm[i] - c*private_m[i]) % o for i in range(len(private_m))]
-	rt = wt - c*t % o
+	rt = (wt - c*t) % o
 	return (c, rm, rt)
 
 def verify_pi_v(params, aggr_vk, sigma, kappa, nu, pi_v):


### PR DESCRIPTION
Just a tiny change to ensure that rt is positive. While the previous version worked perfectly fine, it had an awkard (for me) hex representation due to the minus sign being present.

It also allows for successful call to `rt.binary()` as otherwise an exception is thrown as the method can't handle representing negative numbers.